### PR TITLE
Add Terraform tests and CI

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,26 @@
+name: Terraform
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: us-east-1
+      AWS_EC2_METADATA_DISABLED: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.5"
+      - run: terraform fmt -check -recursive
+      - run: terraform init -backend=false
+      - run: terraform validate
+      - run: terraform test

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.38 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.38, < 6.0 |
 
 ## Providers
 

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.38"
+      version = ">= 3.38, < 6.0"
     }
   }
 }

--- a/main.tftest.hcl
+++ b/main.tftest.hcl
@@ -1,0 +1,82 @@
+mock_provider "aws" {}
+
+run "default_application_lb" {
+  command = plan
+
+  variables {
+    name            = "example"
+    subnets         = ["subnet-1234567890abcdef0", "subnet-abcdef01234567890"]
+    security_groups = ["sg-1234567890abcdef0"]
+    vpc_id          = "vpc-1234567890abcdef0"
+    tags = {
+      environment = "test"
+    }
+  }
+
+  assert {
+    condition     = aws_lb.alb["application"].name == "example-alb"
+    error_message = "Expected the default ALB name to use var.name."
+  }
+
+  assert {
+    condition     = aws_lb.alb["application"].load_balancer_type == "application"
+    error_message = "Expected an application load balancer by default."
+  }
+
+  assert {
+    condition     = length(module.alb-listener) == 1
+    error_message = "Expected a default ALB listener."
+  }
+
+  assert {
+    condition     = length(module.alb-tg) == 1
+    error_message = "Expected a default ALB target group."
+  }
+}
+
+run "network_lb" {
+  command = plan
+
+  variables {
+    name               = "example"
+    load_balancer_type = "network"
+    subnets            = ["subnet-1234567890abcdef0", "subnet-abcdef01234567890"]
+    vpc_id             = "vpc-1234567890abcdef0"
+  }
+
+  assert {
+    condition     = aws_lb.nlb["network"].name == "example-nlb"
+    error_message = "Expected the default NLB name to use var.name."
+  }
+
+  assert {
+    condition     = aws_lb.nlb["network"].load_balancer_type == "network"
+    error_message = "Expected a network load balancer."
+  }
+
+  assert {
+    condition     = length(module.nlb-listener) == 1
+    error_message = "Expected a default NLB listener."
+  }
+}
+
+run "listener_disabled" {
+  command = plan
+
+  variables {
+    name             = "example"
+    default_listener = false
+    subnets          = ["subnet-1234567890abcdef0", "subnet-abcdef01234567890"]
+    vpc_id           = "vpc-1234567890abcdef0"
+  }
+
+  assert {
+    condition     = length(module.alb-listener) == 0
+    error_message = "Expected no default ALB listener when default_listener is false."
+  }
+
+  assert {
+    condition     = length(module.alb-tg) == 0
+    error_message = "Expected no default ALB target group when default_listener is false."
+  }
+}

--- a/modules/lb-listener/README.md
+++ b/modules/lb-listener/README.md
@@ -19,7 +19,7 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.38 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.38, < 6.0 |
 
 ## Providers
 

--- a/modules/lb-listener/main.tf
+++ b/modules/lb-listener/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.38"
+      version = ">= 3.38, < 6.0"
     }
   }
 }

--- a/modules/lb-target-group/README.md
+++ b/modules/lb-target-group/README.md
@@ -19,7 +19,7 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.38 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.38, < 6.0 |
 
 ## Providers
 

--- a/modules/lb-target-group/main.tf
+++ b/modules/lb-target-group/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.38"
+      version = ">= 3.38, < 6.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add native Terraform plan tests for ALB defaults, NLB defaults, and disabled default listeners
- add a pull-request Terraform CI workflow
- keep AWS provider resolution on the current v3/v4/v5 line pending a separate provider-v6 review

## Verification
- terraform fmt -check -recursive
- terraform init -backend=false
- terraform validate
- terraform test