### PR TITLE
Keep Terraform release tags immutable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,12 +22,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           default_bump: none
 
+      - name: Find previous release
+        id: previous-release
+        if: steps.version.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="$(gh release list --exclude-drafts --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName // ""')"
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+
       - name: Create GitHub release
         if: steps.version.outputs.should_release == 'true'
         uses: so1omon563/release-creator@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.version.outputs.new_version }}
+          from-tag: ${{ steps.previous-release.outputs.tag }}
           tag-prefix: v
-          move-major-tag: true
-          move-minor-tag: true


### PR DESCRIPTION
## Summary

- keep Terraform module release tags immutable by not moving floating major/minor tags
- generate release notes from the previous published release when a release is created

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/main.yml"); puts "ok"'`
- `rg -i "Pearson|ported from|role arn|account id|iessre|internal workflow|private repo|private org|anothrNick|github-tag-action|branch_name|move-major-tag|move-minor-tag" .github/workflows/main.yml`
- `git diff --check`
