### PR TITLE
Add public TFLint checks

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -20,6 +20,16 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.7.5"
+      - name: Setup TFLint
+        uses: terraform-linters/setup-tflint@v6
+        with:
+          tflint_version: v0.63.1
+      - name: Initialize TFLint
+        run: tflint --init
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Run TFLint
+        run: tflint --recursive --config "$(pwd)/.tflint.hcl" --format compact
       - run: terraform fmt -check -recursive
       - run: terraform init -backend=false
       - run: terraform validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,12 @@
 repos:
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.17 # Get the latest from: https://github.com/gruntwork-io/pre-commit/releases
+    rev: v0.1.30 # Get the latest from: https://github.com/gruntwork-io/pre-commit/releases
     hooks:
       - id: terraform-fmt
       - id: terraform-validate
+      - id: tflint
+        args:
+          - "--config=__GIT_ROOT__/.tflint.hcl"
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0 # Use the ref you want to point at
     hooks:

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,7 +1,3 @@
-tflint {
-  required_version = ">= 0.63.0"
-}
-
 # Standalone examples and fixtures inherit compatibility from the module.
 rule "terraform_required_providers" {
   enabled = false

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,22 @@
+tflint {
+  required_version = ">= 0.63.0"
+}
+
+# Standalone examples and fixtures inherit compatibility from the module.
+rule "terraform_required_providers" {
+  enabled = false
+}
+
+rule "terraform_required_version" {
+  enabled = false
+}
+
+# Fixture variable typing is tracked separately from lint tooling.
+rule "terraform_typed_variables" {
+  enabled = false
+}
+
+# Retained compatibility declarations are tracked separately from lint tooling.
+rule "terraform_unused_declarations" {
+  enabled = false
+}


### PR DESCRIPTION
## Summary

- install TFLint 0.63.1 with the official setup action and run it recursively in the existing Terraform workflow
- update the Gruntwork pre-commit hooks to v0.1.30 and use its supported TFLint interface
- add a repository-specific TFLint configuration for existing compatibility findings

## Impact

This adds public lint coverage without changing module resources, inputs, outputs, provider constraints, or release behavior. Deferred compatibility and cleanup findings will be handled separately.

## Verification

- `tflint --recursive --config "$(pwd)/.tflint.hcl" --format compact`
- `pre-commit run tflint --all-files`
- `terraform fmt -check -recursive`
- `terraform init -backend=false -input=false`
- `terraform validate`
- `terraform test` (3 passed)
- workflow and pre-commit YAML parsing
- `git diff --check`