### PR TITLE
Add standalone Terraform metadata

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -3,15 +3,6 @@ rule "terraform_required_providers" {
   enabled = false
 }
 
-rule "terraform_required_version" {
-  enabled = false
-}
-
-# Fixture variable typing is tracked separately from lint tooling.
-rule "terraform_typed_variables" {
-  enabled = false
-}
-
 # Retained compatibility declarations are tracked separately from lint tooling.
 rule "terraform_unused_declarations" {
   enabled = false

--- a/examples/basic-usage/README.md
+++ b/examples/basic-usage/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.38, < 6.0"
+      version = ">= 3.55, < 6.0"
     }
     tls = {
       source  = "hashicorp/tls"
@@ -188,15 +188,15 @@ output "nlb" { value = module.nlb }
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.38, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.55, < 6.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.0, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.38, < 6.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.0, < 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 3.4.0 |
 
 ## Modules
 

--- a/examples/basic-usage/README.md
+++ b/examples/basic-usage/README.md
@@ -9,6 +9,21 @@ Example shows using Default Tags in the provider as well as passing additional t
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 0.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.38, < 6.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 3.0, < 4.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {
@@ -170,14 +185,18 @@ output "nlb" { value = module.nlb }
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.38, < 6.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.0, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.35.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.38, < 6.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.0, < 4.0 |
 
 ## Modules
 

--- a/examples/basic-usage/example.tf
+++ b/examples/basic-usage/example.tf
@@ -1,3 +1,18 @@
+terraform {
+  required_version = ">= 0.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.38, < 6.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 3.0, < 4.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {

--- a/examples/basic-usage/example.tf
+++ b/examples/basic-usage/example.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.38, < 6.0"
+      version = ">= 3.55, < 6.0"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/examples/multiple-types/README.md
+++ b/examples/multiple-types/README.md
@@ -11,6 +11,21 @@ Example shows using Default Tags in the provider as well as passing additional t
 ## Examples
 
 ```hcl
+terraform {
+  required_version = ">= 0.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.38, < 6.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 3.0, < 4.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {
@@ -311,14 +326,18 @@ output "nlb-listener-tls" { value = module.nlb-listener-tls }
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.38, < 6.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.0, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.35.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.38, < 6.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.0, < 4.0 |
 
 ## Modules
 

--- a/examples/multiple-types/README.md
+++ b/examples/multiple-types/README.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.38, < 6.0"
+      version = ">= 3.55, < 6.0"
     }
     tls = {
       source  = "hashicorp/tls"
@@ -329,15 +329,15 @@ output "nlb-listener-tls" { value = module.nlb-listener-tls }
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.38, < 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.55, < 6.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.0, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.38, < 6.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.0, < 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 3.4.0 |
 
 ## Modules
 

--- a/examples/multiple-types/example.tf
+++ b/examples/multiple-types/example.tf
@@ -1,3 +1,18 @@
+terraform {
+  required_version = ">= 0.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.38, < 6.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 3.0, < 4.0"
+    }
+  }
+}
+
 provider "aws" {
   default_tags {
     tags = {

--- a/examples/multiple-types/example.tf
+++ b/examples/multiple-types/example.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.38, < 6.0"
+      version = ">= 3.55, < 6.0"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/test/fixture/default/main.tf
+++ b/test/fixture/default/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.38, < 6.0"
+      version = ">= 3.55, < 6.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = ">= 3.0, < 4.0"
+      version = ">= 3.2, < 4.0"
     }
   }
 }

--- a/test/fixture/default/main.tf
+++ b/test/fixture/default/main.tf
@@ -1,5 +1,25 @@
-variable "name" {}
-variable "tags" {}
+terraform {
+  required_version = ">= 0.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.38, < 6.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 3.0, < 4.0"
+    }
+  }
+}
+
+variable "name" {
+  type = string
+}
+
+variable "tags" {
+  type = map(string)
+}
 
 # Create VPC
 module "vpc" {


### PR DESCRIPTION
## Summary

- declare compatible Terraform and provider requirements in standalone examples and fixtures
- add explicit types to fixture and example variables where needed
- regenerate affected example documentation
- remove only the TFLint exceptions resolved by this change

## Validation

- `terraform fmt -check -recursive`
- `tflint --recursive --config "$(pwd)/.tflint.hcl"`
- `terraform init -backend=false`
- `terraform validate`
- `terraform test` (3 passed)
- local fixture `terraform init` / `terraform validate`
- terraform-docs output checks

Tracking: SO1-122