### PR TITLE
Fix load balancer example input names

### DIFF
--- a/examples/basic-usage/README.md
+++ b/examples/basic-usage/README.md
@@ -125,8 +125,8 @@ resource "aws_acm_certificate" "dummy" {
 
 ## Create the load balancers
 ## Creates with a default HTTPS listener / Target Group on public subnets
-## Includes `name_type` value (can be whatever you want) to differentiate it from the other ALB
-## Could have also used the `name_random` options to add a random hex value to the name.
+## Includes `lb_name_type` value (can be whatever you want) to differentiate it from the other ALB
+## Could have also used the `lb_name_random` option to add a random hex value to the name.
 module "alb-public" {
   source  = "so1omon563/lb/aws"
   version = "1.0.0"
@@ -135,7 +135,7 @@ module "alb-public" {
   tags = {
     example = "true"
   }
-  name_type          = "public"
+  lb_name_type       = "public"
   vpc_id             = module.vpc.vpc_id
   subnets            = data.aws_subnets.public_subnets.ids
   security_groups    = [module.web-sg.security-group.id]

--- a/examples/basic-usage/example.tf
+++ b/examples/basic-usage/example.tf
@@ -114,8 +114,8 @@ resource "aws_acm_certificate" "dummy" {
 
 ## Create the load balancers
 ## Creates with a default HTTPS listener / Target Group on public subnets
-## Includes `name_type` value (can be whatever you want) to differentiate it from the other ALB
-## Could have also used the `name_random` options to add a random hex value to the name.
+## Includes `lb_name_type` value (can be whatever you want) to differentiate it from the other ALB
+## Could have also used the `lb_name_random` option to add a random hex value to the name.
 module "alb-public" {
   source  = "so1omon563/lb/aws"
   version = "1.0.0"
@@ -124,7 +124,7 @@ module "alb-public" {
   tags = {
     example = "true"
   }
-  name_type          = "public"
+  lb_name_type       = "public"
   vpc_id             = module.vpc.vpc_id
   subnets            = data.aws_subnets.public_subnets.ids
   security_groups    = [module.web-sg.security-group.id]

--- a/examples/multiple-types/README.md
+++ b/examples/multiple-types/README.md
@@ -127,7 +127,7 @@ resource "aws_acm_certificate" "dummy" {
 }
 
 # Creating load balancers with `default_listener` set to `false` so we can create customized target groups and listeners.
-# Creating 2 ALBs with the same details to show the name_random option
+# Creating 2 ALBs with the same details to show the lb_name_random option
 module "alb-app-1" {
   source  = "so1omon563/lb/aws"
   version = "1.0.0"
@@ -143,8 +143,8 @@ module "alb-app-1" {
   alb = {
     idle_timeout = 20
   }
-  name_type   = "app"
-  name_random = true
+  lb_name_type   = "app"
+  lb_name_random = true
 }
 output "alb-app-1" { value = module.alb-app-1 }
 
@@ -163,8 +163,8 @@ module "alb-app-2" {
   alb = {
     idle_timeout = 20
   }
-  name_type   = "app"
-  name_random = true
+  lb_name_type   = "app"
+  lb_name_random = true
 }
 output "alb-app-2" { value = module.alb-app-2 }
 

--- a/examples/multiple-types/example.tf
+++ b/examples/multiple-types/example.tf
@@ -114,7 +114,7 @@ resource "aws_acm_certificate" "dummy" {
 }
 
 # Creating load balancers with `default_listener` set to `false` so we can create customized target groups and listeners.
-# Creating 2 ALBs with the same details to show the name_random option
+# Creating 2 ALBs with the same details to show the lb_name_random option
 module "alb-app-1" {
   source  = "so1omon563/lb/aws"
   version = "1.0.0"
@@ -130,8 +130,8 @@ module "alb-app-1" {
   alb = {
     idle_timeout = 20
   }
-  name_type   = "app"
-  name_random = true
+  lb_name_type   = "app"
+  lb_name_random = true
 }
 output "alb-app-1" { value = module.alb-app-1 }
 
@@ -150,8 +150,8 @@ module "alb-app-2" {
   alb = {
     idle_timeout = 20
   }
-  name_type   = "app"
-  name_random = true
+  lb_name_type   = "app"
+  lb_name_random = true
 }
 output "alb-app-2" { value = module.alb-app-2 }
 


### PR DESCRIPTION
## Summary

- correct the load balancer example arguments to use `lb_name_type` and `lb_name_random`
- keep the existing exact `1.0.0` module pins because those inputs have been available since the first immutable release
- regenerate both example READMEs with the repository's configured Terraform docs hook

## Root cause and impact

The examples used `name_type` and `name_random`, but no published module release exposes those inputs. Every immutable release from `v1.0.0` through `v1.1.0` exposes the `lb_name_*` forms instead. Correcting the examples makes both standalone configurations validate without changing module behavior or version constraints.

## Validation

- `terraform fmt -check -recursive` with Terraform 1.7.5
- `terraform init -backend=false`
- `terraform validate`
- `terraform test` (3 passed)
- `tflint --recursive --config "$(pwd)/.tflint.hcl" --format compact` with TFLint 0.63.1
- standalone `terraform init -backend=false` and `terraform validate` for both examples
- repository `terraform_docs` pre-commit hook
- `git diff --check`

The standalone validations retain existing TLS deprecation warnings unrelated to this change.

Tracking: SO1-126