### PR TITLE
Declare Random provider requirement

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,8 +1,3 @@
-# Standalone examples and fixtures inherit compatibility from the module.
-rule "terraform_required_providers" {
-  enabled = false
-}
-
 # Retained compatibility declarations are tracked separately from lint tooling.
 rule "terraform_unused_declarations" {
   enabled = false

--- a/README.md
+++ b/README.md
@@ -28,13 +28,14 @@ Auto-generated technical documentation is created using [`terraform-docs`](https
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.38, < 6.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.35.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -8,5 +8,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.38, < 6.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.1"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- declare `hashicorp/random >= 3.1` in the module root
- re-enable the `terraform_required_providers` TFLint rule
- regenerate the root provider documentation

## Why

The module creates a `random_id` resource but only declared its AWS provider dependency. Random 3.1 is the first 3.x release with a darwin-arm64 build and does not change provider behavior from 3.0. The minimum-only constraint follows reusable-module guidance without raising the Terraform or AWS provider floors.

## Validation

- Terraform 1.7.5 `fmt -check -recursive`
- Terraform 1.7.5 `init -backend=false -upgrade`
- Terraform 1.7.5 `validate`
- Terraform 1.7.5 `test`
- TFLint 0.63.1 recursive lint with `terraform_required_providers` enabled
- terraform-docs pre-commit hook
- `git diff --check`

Linear: SO1-100