### PR TITLE
Default releases to patch bumps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         uses: so1omon563/custom-semver-bumper@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          default_bump: none
+          default_bump: patch
 
       - name: Find previous release
         id: previous-release


### PR DESCRIPTION
## Summary

- default ordinary merges to a patch version bump
- keep GitHub Release publication separately marker-gated
- make no module, Terraform, provider, or version-floor changes

## Validation

- `actionlint .github/workflows/main.yml`
- `git diff --check`
- verified all nine refreshed Terraform modules now declare `default_bump: patch`

Linear: [SO1-130](https://linear.app/so1omon563/issue/SO1-130/standardize-patch-default-releases-across-terraform-modules)